### PR TITLE
Enabled "react/prop-types" & added PropTypes to files that require them.

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -41,7 +41,6 @@ export default defineConfig([
       "react/react-in-jsx-scope": "off", //Recomended by React - https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
       "react/jsx-uses-react": "off", //Recomended by React - https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
       "react/react-in-jsx-scope": "off",
-      "react/prop-types": "off",           
       "react/display-name": "off",         
       "react/no-unescaped-entities": "off" 
     },

--- a/frontend/src/main/components/Assignments/IndividualAssignmentForm.jsx
+++ b/frontend/src/main/components/Assignments/IndividualAssignmentForm.jsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form";
 import { Button, Form } from "react-bootstrap";
-
+import PropTypes from "prop-types";
 export default function IndividualAssignmentForm({ submitAction }) {
   const {
     register,
@@ -61,3 +61,7 @@ export default function IndividualAssignmentForm({ submitAction }) {
     </Form>
   );
 }
+
+IndividualAssignmentForm.propTypes = {
+  submitAction: PropTypes.func.isRequired,
+};

--- a/frontend/src/main/components/Auth/SignInCard.jsx
+++ b/frontend/src/main/components/Auth/SignInCard.jsx
@@ -1,4 +1,5 @@
 import { Button, Card } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 export default function SignInCard({
   url,
@@ -33,3 +34,12 @@ export default function SignInCard({
     </Card>
   );
 }
+
+SignInCard.propTypes = {
+  url: PropTypes.string.isRequired,
+  Icon: PropTypes.elementType.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  testid: PropTypes.string,
+  onClick: PropTypes.func.isRequired,
+};

--- a/frontend/src/main/components/Common/ConfirmationModal.jsx
+++ b/frontend/src/main/components/Common/ConfirmationModal.jsx
@@ -1,5 +1,6 @@
 import Modal from "react-bootstrap/Modal";
 import { Button } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 export default function ConfirmationModal({
   children,
@@ -45,3 +46,10 @@ export default function ConfirmationModal({
     </Modal>
   );
 }
+
+ConfirmationModal.propTypes = {
+  children: PropTypes.node.isRequired,
+  showModal: PropTypes.bool.isRequired,
+  setShowModal: PropTypes.func.isRequired,
+  onYes: PropTypes.func.isRequired,
+};

--- a/frontend/src/main/components/Common/GithubSettingIcon.jsx
+++ b/frontend/src/main/components/Common/GithubSettingIcon.jsx
@@ -1,4 +1,5 @@
 import { FaGear, FaGithub } from "react-icons/fa6";
+import PropTypes from "prop-types";
 
 export default function GithubSettingIcon({
   size = 24,
@@ -30,3 +31,10 @@ export default function GithubSettingIcon({
     </span>
   );
 }
+
+GithubSettingIcon.propTypes = {
+  size: PropTypes.number,
+  gearColor: PropTypes.string,
+  githubColor: PropTypes.string,
+  "data-testid": PropTypes.string,
+};

--- a/frontend/src/main/components/Common/OurPagination.jsx
+++ b/frontend/src/main/components/Common/OurPagination.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Pagination } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 const OurPagination = ({
   currentActivePage,
@@ -101,6 +102,13 @@ const OurPagination = ({
       <Pagination.Next onClick={nextPage} data-testid={`${testId}-next`} />
     </Pagination>
   );
+};
+
+OurPagination.propTypes = {
+  currentActivePage: PropTypes.number.isRequired,
+  updateActivePage: PropTypes.func.isRequired,
+  totalPages: PropTypes.number,
+  testId: PropTypes.string,
 };
 
 export default OurPagination;

--- a/frontend/src/main/components/Common/SortCaret.jsx
+++ b/frontend/src/main/components/Common/SortCaret.jsx
@@ -1,4 +1,5 @@
 import { getSortCaret } from "main/components/Common/SortCaretUtils";
+import PropTypes from "prop-types";
 
 export default function SortCaret({ header, testId = "testid" }) {
   return (
@@ -7,3 +8,12 @@ export default function SortCaret({ header, testId = "testid" }) {
     </span>
   );
 }
+
+SortCaret.propTypes = {
+  header: PropTypes.shape({
+    column: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  testId: PropTypes.string,
+};

--- a/frontend/src/main/components/CourseStaff/CourseStaffForm.jsx
+++ b/frontend/src/main/components/CourseStaff/CourseStaffForm.jsx
@@ -2,6 +2,7 @@ import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 import regexUtils from "main/utils/regexUtils";
+import PropTypes from "prop-types";
 
 function CourseStaffForm({
   initialContents,
@@ -106,5 +107,17 @@ function CourseStaffForm({
     </Form>
   );
 }
+
+CourseStaffForm.propTypes = {
+  initialContents: PropTypes.shape({
+    email: PropTypes.string,
+    firstname: PropTypes.string,
+    lastname: PropTypes.string,
+  }),
+  submitAction: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  buttonLabel: PropTypes.string,
+  cancelDisabled: PropTypes.bool,
+};
 
 export default CourseStaffForm;

--- a/frontend/src/main/components/CourseStaff/CourseStaffTable.jsx
+++ b/frontend/src/main/components/CourseStaff/CourseStaffTable.jsx
@@ -7,6 +7,7 @@ import { hasRole } from "main/utils/currentUser";
 import Modal from "react-bootstrap/Modal";
 import CourseStaffForm from "main/components/CourseStaff/CourseStaffForm";
 import { toast } from "react-toastify";
+import PropTypes from "prop-types";
 
 export default function CourseStaffTable({
   staff,
@@ -231,3 +232,23 @@ export default function CourseStaffTable({
     </>
   );
 }
+
+CourseStaffTable.propTypes = {
+  staff: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+      email: PropTypes.string,
+      githubLogin: PropTypes.string,
+      orgStatus: PropTypes.string,
+    }),
+  ).isRequired,
+  currentUser: PropTypes.shape({
+    root: PropTypes.shape({
+      rolesList: PropTypes.arrayOf(PropTypes.string),
+    }),
+  }).isRequired,
+  courseId: PropTypes.string.isRequired,
+  testIdPrefix: PropTypes.string,
+};

--- a/frontend/src/main/components/Courses/CourseModal.jsx
+++ b/frontend/src/main/components/Courses/CourseModal.jsx
@@ -2,6 +2,7 @@ import Modal from "react-bootstrap/Modal";
 import { Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useEffect } from "react";
+import PropTypes from "prop-types";
 
 function CourseModal({
   onSubmitAction,
@@ -103,5 +104,18 @@ function CourseModal({
     </Modal>
   );
 }
+
+CourseModal.propTypes = {
+  onSubmitAction: PropTypes.func.isRequired,
+  showModal: PropTypes.bool.isRequired,
+  toggleShowModal: PropTypes.func.isRequired,
+  initialContents: PropTypes.shape({
+    courseName: PropTypes.string,
+    term: PropTypes.string,
+    school: PropTypes.string,
+  }),
+  buttonText: PropTypes.string,
+  modalTitle: PropTypes.string,
+};
 
 export default CourseModal;

--- a/frontend/src/main/components/Courses/CoursesTable.jsx
+++ b/frontend/src/main/components/Courses/CoursesTable.jsx
@@ -1,5 +1,6 @@
 import OurTable from "main/components/OurTable";
 import { Tooltip, OverlayTrigger, Button, Spinner } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 const columns = [
   {
@@ -159,3 +160,19 @@ export default function CoursesTable({
     <OurTable data={courses} columns={columnsWithStatus} testid={testId} />
   );
 }
+
+CoursesTable.propTypes = {
+  courses: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.any.isRequired,
+      courseName: PropTypes.string.isRequired,
+      term: PropTypes.string.isRequired,
+      school: PropTypes.string.isRequired,
+      studentStatus: PropTypes.string.isRequired,
+      orgName: PropTypes.string,
+    }),
+  ).isRequired,
+  testId: PropTypes.string.isRequired,
+  joinCallback: PropTypes.func.isRequired,
+  isLoading: PropTypes.func.isRequired,
+};

--- a/frontend/src/main/components/Courses/InstructorCoursesTable.jsx
+++ b/frontend/src/main/components/Courses/InstructorCoursesTable.jsx
@@ -10,6 +10,7 @@ import UpdateInstructorForm from "main/components/Courses/UpdateInstructorForm";
 import CourseModal from "main/components/Courses/CourseModal";
 import Modal from "react-bootstrap/Modal";
 import { useLocation } from "react-router";
+import PropTypes from "prop-types";
 
 export default function InstructorCoursesTable({
   courses,
@@ -375,3 +376,30 @@ export default function InstructorCoursesTable({
     </>
   );
 }
+
+InstructorCoursesTable.propTypes = {
+  courses: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      courseName: PropTypes.string.isRequired,
+      term: PropTypes.string.isRequired,
+      school: PropTypes.string.isRequired,
+      instructorEmail: PropTypes.string.isRequired,
+      numStudents: PropTypes.number,
+      numStaff: PropTypes.number,
+      orgName: PropTypes.string,
+      installationId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    }),
+  ).isRequired,
+  storybook: PropTypes.bool,
+  currentUser: PropTypes.shape({
+    root: PropTypes.shape({
+      user: PropTypes.shape({
+        email: PropTypes.string.isRequired,
+      }).isRequired,
+      rolesList: PropTypes.arrayOf(PropTypes.string),
+    }).isRequired,
+  }).isRequired,
+  testId: PropTypes.string,
+  enableInstructorUpdate: PropTypes.bool,
+};

--- a/frontend/src/main/components/Courses/UpdateInstructorForm.jsx
+++ b/frontend/src/main/components/Courses/UpdateInstructorForm.jsx
@@ -1,5 +1,6 @@
 import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
+import PropTypes from "prop-types";
 
 export default function UpdateInstructorForm({
   initialContents,
@@ -48,3 +49,11 @@ export default function UpdateInstructorForm({
     </Form>
   );
 }
+
+UpdateInstructorForm.propTypes = {
+  initialContents: PropTypes.shape({
+    courseName: PropTypes.string,
+    instructorEmail: PropTypes.string,
+  }),
+  handleUpdateInstructor: PropTypes.func.isRequired,
+};

--- a/frontend/src/main/components/Jobs/JobsTable.jsx
+++ b/frontend/src/main/components/Jobs/JobsTable.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import OurTable from "main/components/OurTable";
 import { formatTime } from "main/utils/dateUtils";
+import PropTypes from "prop-types";
 
 export default function JobsTable({ jobs }) {
   const columns = [
@@ -40,3 +41,15 @@ export default function JobsTable({ jobs }) {
 
   return <OurTable data={jobs} columns={columns} testid={testid} />;
 }
+
+JobsTable.propTypes = {
+  jobs: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      createdAt: PropTypes.string.isRequired,
+      updatedAt: PropTypes.string.isRequired,
+      status: PropTypes.string.isRequired,
+      log: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+};

--- a/frontend/src/main/components/Jobs/SingleButtonJobForm.jsx
+++ b/frontend/src/main/components/Jobs/SingleButtonJobForm.jsx
@@ -1,4 +1,5 @@
 import { Button } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 export default function SingleButtonJobForm({ callback, text, testid }) {
   return (
@@ -7,3 +8,9 @@ export default function SingleButtonJobForm({ callback, text, testid }) {
     </Button>
   );
 }
+
+SingleButtonJobForm.propTypes = {
+  callback: PropTypes.func.isRequired,
+  text: PropTypes.string.isRequired,
+  testid: PropTypes.string.isRequired,
+};

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -4,6 +4,7 @@ import { hasRole } from "main/utils/currentUser";
 import AppNavbarLocalhost from "main/components/Nav/AppNavbarLocalhost";
 import GoogleLogin from "main/components/Nav/GoogleLogin";
 import GithubLogin from "main/components/Nav/GithubLogin";
+import PropTypes from "prop-types";
 
 export default function AppNavbar({
   currentUser,
@@ -98,3 +99,17 @@ export default function AppNavbar({
     </>
   );
 }
+
+AppNavbar.propTypes = {
+  currentUser: PropTypes.shape({
+    root: PropTypes.shape({
+      rolesList: PropTypes.arrayOf(PropTypes.string),
+    }),
+  }).isRequired,
+  systemInfo: PropTypes.shape({
+    showSwaggerUILink: PropTypes.bool,
+    springH2ConsoleEnabled: PropTypes.bool,
+  }),
+  doLogout: PropTypes.func,
+  currentUrl: PropTypes.string,
+};

--- a/frontend/src/main/components/Nav/AppNavbarLocalhost.jsx
+++ b/frontend/src/main/components/Nav/AppNavbarLocalhost.jsx
@@ -1,4 +1,5 @@
 import { Container, Nav, Navbar } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 export default function AppNavbarLocalhost({ url }) {
   return (
@@ -33,3 +34,7 @@ export default function AppNavbarLocalhost({ url }) {
     </>
   );
 }
+
+AppNavbarLocalhost.propTypes = {
+  url: PropTypes.string.isRequired,
+};

--- a/frontend/src/main/components/Nav/GithubLogin.jsx
+++ b/frontend/src/main/components/Nav/GithubLogin.jsx
@@ -1,5 +1,6 @@
 import { Button, Navbar } from "react-bootstrap";
 import { Link } from "react-router";
+import PropTypes from "prop-types";
 
 export default function GithubLogin({ currentUser, systemInfo }) {
   var githubOauthLogin =
@@ -22,3 +23,17 @@ export default function GithubLogin({ currentUser, systemInfo }) {
     </>
   );
 }
+
+GithubLogin.propTypes = {
+  currentUser: PropTypes.shape({
+    loggedIn: PropTypes.bool,
+    root: PropTypes.shape({
+      user: PropTypes.shape({
+        githubLogin: PropTypes.string,
+      }),
+    }),
+  }),
+  systemInfo: PropTypes.shape({
+    githubOauthLogin: PropTypes.string,
+  }),
+};

--- a/frontend/src/main/components/Nav/GoogleLogin.jsx
+++ b/frontend/src/main/components/Nav/GoogleLogin.jsx
@@ -1,6 +1,7 @@
 import { Button, Navbar } from "react-bootstrap";
 import { Link } from "react-router";
 import HelpMenu from "main/components/Nav/HelpMenu";
+import PropTypes from "prop-types";
 
 export default function GoogleLogin({ currentUser, handleLogin, doLogout }) {
   return (
@@ -22,3 +23,16 @@ export default function GoogleLogin({ currentUser, handleLogin, doLogout }) {
     </>
   );
 }
+
+GoogleLogin.propTypes = {
+  currentUser: PropTypes.shape({
+    loggedIn: PropTypes.bool,
+    root: PropTypes.shape({
+      user: PropTypes.shape({
+        email: PropTypes.string,
+      }),
+    }),
+  }),
+  handleLogin: PropTypes.func.isRequired,
+  doLogout: PropTypes.func.isRequired,
+};

--- a/frontend/src/main/components/OurTable.jsx
+++ b/frontend/src/main/components/OurTable.jsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "react-bootstrap";
 import SortCaret from "main/components/Common/SortCaret";
 import { convertOldStyleColumnsToNewStyle } from "main/components/OurTableUtils";
+import PropTypes from "prop-types";
 
 function OurTable({ data, columns, testid = "testid" }) {
   const newColumns = convertOldStyleColumnsToNewStyle(columns);
@@ -107,3 +108,9 @@ export function ButtonColumn(label, variant, callback, testid) {
   });
   return buttonColumn;
 }
+
+OurTable.propTypes = {
+  data: PropTypes.array.isRequired,
+  columns: PropTypes.array.isRequired,
+  testid: PropTypes.string,
+};

--- a/frontend/src/main/components/Profile/RoleBadge.jsx
+++ b/frontend/src/main/components/Profile/RoleBadge.jsx
@@ -1,4 +1,5 @@
 import { Badge } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 export default function RoleBadge({ role, currentUser }) {
   const roles = currentUser.root.roles.map((o) => o.authority);
@@ -12,3 +13,16 @@ export default function RoleBadge({ role, currentUser }) {
     <span data-testid={`role-missing-${lcrole}`}></span>
   );
 }
+
+RoleBadge.propTypes = {
+  role: PropTypes.string.isRequired,
+  currentUser: PropTypes.shape({
+    root: PropTypes.shape({
+      roles: PropTypes.arrayOf(
+        PropTypes.shape({
+          authority: PropTypes.string,
+        }),
+      ),
+    }),
+  }).isRequired,
+};

--- a/frontend/src/main/components/RepositorySelectionForm.jsx
+++ b/frontend/src/main/components/RepositorySelectionForm.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Form, Button } from "react-bootstrap";
 import { FaCheckCircle } from "react-icons/fa";
+import PropTypes from "prop-types";
 
 function RepositorySelectionForm({ collections = [] }) {
   const [url, setURL] = useState("");
@@ -144,4 +145,9 @@ function RepositorySelectionForm({ collections = [] }) {
     </Form>
   );
 }
+
+RepositorySelectionForm.propTypes = {
+  collections: PropTypes.arrayOf(PropTypes.string),
+};
+
 export default RepositorySelectionForm;

--- a/frontend/src/main/components/RosterStudent/DroppedStudentsTable.jsx
+++ b/frontend/src/main/components/RosterStudent/DroppedStudentsTable.jsx
@@ -1,6 +1,7 @@
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
+import PropTypes from "prop-types";
 
 export default function DroppedStudentsTable({ students, courseId }) {
   const columns = [
@@ -65,3 +66,16 @@ export default function DroppedStudentsTable({ students, courseId }) {
     />
   );
 }
+
+DroppedStudentsTable.propTypes = {
+  students: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      studentId: PropTypes.string,
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+      email: PropTypes.string,
+    }),
+  ).isRequired,
+  courseId: PropTypes.string.isRequired,
+};

--- a/frontend/src/main/components/RosterStudent/RosterStudentCSVUploadForm.jsx
+++ b/frontend/src/main/components/RosterStudent/RosterStudentCSVUploadForm.jsx
@@ -1,6 +1,7 @@
 import { useForm } from "react-hook-form";
 import { Button, Form } from "react-bootstrap";
 import React from "react";
+import PropTypes from "prop-types";
 
 export default function RosterStudentCSVUploadForm({ submitAction }) {
   const {
@@ -35,3 +36,7 @@ export default function RosterStudentCSVUploadForm({ submitAction }) {
     </Form>
   );
 }
+
+RosterStudentCSVUploadForm.propTypes = {
+  submitAction: PropTypes.func.isRequired,
+};

--- a/frontend/src/main/components/RosterStudent/RosterStudentDeleteModal.jsx
+++ b/frontend/src/main/components/RosterStudent/RosterStudentDeleteModal.jsx
@@ -1,6 +1,7 @@
 import Modal from "react-bootstrap/Modal";
 import { useForm } from "react-hook-form";
 import { Form } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 export default function RosterStudentDeleteModal({
   onSubmitAction,
@@ -53,3 +54,9 @@ export default function RosterStudentDeleteModal({
     </Modal>
   );
 }
+
+RosterStudentDeleteModal.propTypes = {
+  onSubmitAction: PropTypes.func.isRequired,
+  showModal: PropTypes.bool.isRequired,
+  toggleShowModal: PropTypes.func.isRequired,
+};

--- a/frontend/src/main/components/RosterStudent/RosterStudentDropdown.jsx
+++ b/frontend/src/main/components/RosterStudent/RosterStudentDropdown.jsx
@@ -1,4 +1,5 @@
 import { Form } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 export default function RosterStudentDropdown({ rosterStudents, register }) {
   return (
@@ -19,3 +20,14 @@ export default function RosterStudentDropdown({ rosterStudents, register }) {
     </Form.Control>
   );
 }
+
+RosterStudentDropdown.propTypes = {
+  rosterStudents: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      firstName: PropTypes.string.isRequired,
+      lastName: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  register: PropTypes.func.isRequired,
+};

--- a/frontend/src/main/components/RosterStudent/RosterStudentForm.jsx
+++ b/frontend/src/main/components/RosterStudent/RosterStudentForm.jsx
@@ -2,6 +2,7 @@ import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 import regexUtils from "main/utils/regexUtils";
+import PropTypes from "prop-types";
 
 function RosterStudentForm({
   initialContents,
@@ -121,5 +122,16 @@ function RosterStudentForm({
     </Form>
   );
 }
+RosterStudentForm.propTypes = {
+  initialContents: PropTypes.shape({
+    studentId: PropTypes.string,
+    firstName: PropTypes.string,
+    lastName: PropTypes.string,
+    email: PropTypes.string,
+  }),
+  submitAction: PropTypes.func.isRequired,
+  buttonLabel: PropTypes.string,
+  cancelDisabled: PropTypes.bool,
+};
 
 export default RosterStudentForm;

--- a/frontend/src/main/components/RosterStudent/RosterStudentTable.jsx
+++ b/frontend/src/main/components/RosterStudent/RosterStudentTable.jsx
@@ -9,6 +9,7 @@ import Modal from "react-bootstrap/Modal";
 import RosterStudentForm from "main/components/RosterStudent/RosterStudentForm";
 import { toast } from "react-toastify";
 import RosterStudentDeleteModal from "main/components/RosterStudent/RosterStudentDeleteModal";
+import PropTypes from "prop-types";
 
 export default function RosterStudentTable({
   students,
@@ -254,3 +255,25 @@ export default function RosterStudentTable({
     </>
   );
 }
+
+RosterStudentTable.propTypes = {
+  students: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      studentId: PropTypes.string,
+      firstName: PropTypes.string.isRequired,
+      lastName: PropTypes.string.isRequired,
+      email: PropTypes.string.isRequired,
+      githubLogin: PropTypes.string,
+      teams: PropTypes.arrayOf(PropTypes.string),
+      orgStatus: PropTypes.string,
+    }),
+  ).isRequired,
+  currentUser: PropTypes.shape({
+    root: PropTypes.shape({
+      rolesList: PropTypes.arrayOf(PropTypes.string),
+    }),
+  }).isRequired,
+  courseId: PropTypes.string.isRequired,
+  testIdPrefix: PropTypes.string,
+};

--- a/frontend/src/main/components/TabComponent/AssignmentTabComponent.jsx
+++ b/frontend/src/main/components/TabComponent/AssignmentTabComponent.jsx
@@ -2,7 +2,7 @@ import IndividualAssignmentForm from "main/components/Assignments/IndividualAssi
 import { Card, Row } from "react-bootstrap";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
-
+import PropTypes from "prop-types";
 export default function AssignmentTabComponent({ courseId }) {
   const onSuccessAssignment = () => {
     toast("Repository creation successfully started.");
@@ -38,3 +38,7 @@ export default function AssignmentTabComponent({ courseId }) {
     </Row>
   );
 }
+
+AssignmentTabComponent.propTypes = {
+  courseId: PropTypes.string.isRequired,
+};

--- a/frontend/src/main/components/TabComponent/EnrollmentTabComponent.jsx
+++ b/frontend/src/main/components/TabComponent/EnrollmentTabComponent.jsx
@@ -14,6 +14,7 @@ import RosterStudentForm from "main/components/RosterStudent/RosterStudentForm";
 import RosterStudentTable from "main/components/RosterStudent/RosterStudentTable";
 import Modal from "react-bootstrap/Modal";
 import DroppedStudentsTable from "main/components/RosterStudent/DroppedStudentsTable";
+import PropTypes from "prop-types";
 
 export default function EnrollmentTabComponent({
   courseId,
@@ -238,3 +239,9 @@ export default function EnrollmentTabComponent({
     </div>
   );
 }
+
+EnrollmentTabComponent.propTypes = {
+  courseId: PropTypes.string.isRequired,
+  testIdPrefix: PropTypes.string.isRequired,
+  currentUser: PropTypes.object.isRequired,
+};

--- a/frontend/src/main/components/TabComponent/StaffTabComponent.jsx
+++ b/frontend/src/main/components/TabComponent/StaffTabComponent.jsx
@@ -14,6 +14,7 @@ import {
 import CourseStaffForm from "main/components/CourseStaff/CourseStaffForm";
 import CourseStaffTable from "main/components/CourseStaff/CourseStaffTable";
 import Modal from "react-bootstrap/Modal";
+import PropTypes from "prop-types";
 
 export default function StaffTabComponent({
   courseId,
@@ -163,3 +164,8 @@ export default function StaffTabComponent({
     </div>
   );
 }
+StaffTabComponent.propTypes = {
+  courseId: PropTypes.string.isRequired,
+  testIdPrefix: PropTypes.string.isRequired,
+  currentUser: PropTypes.object.isRequired,
+};

--- a/frontend/src/main/components/TabComponent/TeamsTabComponent.jsx
+++ b/frontend/src/main/components/TabComponent/TeamsTabComponent.jsx
@@ -13,6 +13,7 @@ import TeamsCSVUploadForm from "main/components/Teams/TeamsCSVUploadForm";
 import TeamsForm from "main/components/Teams/TeamsForm";
 import Modal from "react-bootstrap/Modal";
 import TeamsTable from "main/components/Teams/TeamsTable";
+import PropTypes from "prop-types";
 
 export default function TeamsTabComponent({
   courseId,
@@ -276,3 +277,9 @@ export default function TeamsTabComponent({
     </div>
   );
 }
+
+TeamsTabComponent.propTypes = {
+  courseId: PropTypes.string.isRequired,
+  testIdPrefix: PropTypes.string.isRequired,
+  currentUser: PropTypes.object.isRequired,
+};

--- a/frontend/src/main/components/Teams/TeamMemberForm.jsx
+++ b/frontend/src/main/components/Teams/TeamMemberForm.jsx
@@ -2,6 +2,7 @@ import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 import RosterStudentDropdown from "main/components/RosterStudent/RosterStudentDropdown";
+import PropTypes from "prop-types";
 
 function TeamMemberForm({
   initialContents,
@@ -52,5 +53,13 @@ function TeamMemberForm({
     </Form>
   );
 }
+
+TeamMemberForm.propTypes = {
+  initialContents: PropTypes.object,
+  rosterStudents: PropTypes.arrayOf(PropTypes.object).isRequired,
+  submitAction: PropTypes.func.isRequired,
+  buttonLabel: PropTypes.string,
+  cancelDisabled: PropTypes.bool,
+};
 
 export default TeamMemberForm;

--- a/frontend/src/main/components/Teams/TeamsCSVUploadForm.jsx
+++ b/frontend/src/main/components/Teams/TeamsCSVUploadForm.jsx
@@ -1,6 +1,7 @@
 import { useForm } from "react-hook-form";
 import { Button, Form } from "react-bootstrap";
 import React from "react";
+import PropTypes from "prop-types";
 
 export default function TeamsCSVUploadForm({ submitAction }) {
   const {
@@ -37,3 +38,7 @@ export default function TeamsCSVUploadForm({ submitAction }) {
     </Form>
   );
 }
+
+TeamsCSVUploadForm.propTypes = {
+  submitAction: PropTypes.func.isRequired,
+};

--- a/frontend/src/main/components/Teams/TeamsForm.jsx
+++ b/frontend/src/main/components/Teams/TeamsForm.jsx
@@ -1,6 +1,7 @@
 import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
+import PropTypes from "prop-types";
 
 function TeamsForm({
   initialContents,
@@ -53,5 +54,12 @@ function TeamsForm({
     </Form>
   );
 }
+
+TeamsForm.propTypes = {
+  initialContents: PropTypes.object,
+  submitAction: PropTypes.func.isRequired,
+  buttonLabel: PropTypes.string,
+  cancelDisabled: PropTypes.bool,
+};
 
 export default TeamsForm;

--- a/frontend/src/main/components/Teams/TeamsTable.jsx
+++ b/frontend/src/main/components/Teams/TeamsTable.jsx
@@ -11,6 +11,7 @@ import { useBackend } from "main/utils/useBackend";
 import Modal from "react-bootstrap/Modal";
 import { ModalBody, ModalHeader } from "react-bootstrap";
 import TeamMemberForm from "main/components/Teams/TeamMemberForm";
+import PropTypes from "prop-types";
 
 export default function TeamsTable({
   teams,
@@ -223,3 +224,31 @@ export default function TeamsTable({
     </>
   );
 }
+
+TeamsTable.propTypes = {
+  teams: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      teamMembers: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.string.isRequired,
+          rosterStudent: PropTypes.shape({
+            id: PropTypes.number.isRequired,
+            firstName: PropTypes.string.isRequired,
+            lastName: PropTypes.string.isRequired,
+            email: PropTypes.string.isRequired,
+            githubLogin: PropTypes.string.isRequired,
+          }).isRequired,
+        }),
+      ).isRequired,
+    }),
+  ).isRequired,
+  currentUser: PropTypes.shape({
+    root: PropTypes.shape({
+      rolesList: PropTypes.arrayOf(PropTypes.string),
+    }),
+  }).isRequired,
+  courseId: PropTypes.string.isRequired,
+  testIdPrefix: PropTypes.string,
+};

--- a/frontend/src/main/components/Users/RoleEmailForm.jsx
+++ b/frontend/src/main/components/Users/RoleEmailForm.jsx
@@ -1,6 +1,7 @@
 import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
+import PropTypes from "prop-types";
 
 function RoleEmailForm({ submitAction, buttonLabel = "Create" }) {
   // Stryker disable all
@@ -51,5 +52,10 @@ function RoleEmailForm({ submitAction, buttonLabel = "Create" }) {
     </Form>
   );
 }
+
+RoleEmailForm.propTypes = {
+  submitAction: PropTypes.func.isRequired,
+  buttonLabel: PropTypes.string,
+};
 
 export default RoleEmailForm;

--- a/frontend/src/main/components/Users/RoleEmailTable.jsx
+++ b/frontend/src/main/components/Users/RoleEmailTable.jsx
@@ -4,6 +4,7 @@ import OurTable from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 import { Button } from "react-bootstrap";
+import PropTypes from "prop-types";
 
 export default function RoleEmailTable({
   data,
@@ -76,3 +77,16 @@ export default function RoleEmailTable({
     />
   );
 }
+
+RoleEmailTable.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      email: PropTypes.string.isRequired,
+      isInAdminEmails: PropTypes.bool.isRequired,
+    }),
+  ).isRequired,
+  deleteEndpoint: PropTypes.string,
+  getEndpoint: PropTypes.string,
+  testIdPrefix: PropTypes.string,
+  customDeleteCallback: PropTypes.func,
+};

--- a/frontend/src/main/components/Users/UsersTable.jsx
+++ b/frontend/src/main/components/Users/UsersTable.jsx
@@ -1,4 +1,5 @@
 import OurTable from "main/components/OurTable";
+import PropTypes from "prop-types";
 
 const columns = [
   {
@@ -38,3 +39,16 @@ const columns = [
 export default function UsersTable({ users }) {
   return <OurTable data={users} columns={columns} testid={"UsersTable"} />;
 }
+
+UsersTable.propTypes = {
+  users: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      givenName: PropTypes.string,
+      familyName: PropTypes.string,
+      email: PropTypes.string,
+      admin: PropTypes.bool,
+      instructor: PropTypes.bool,
+    }),
+  ).isRequired,
+};

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.jsx
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.jsx
@@ -3,6 +3,7 @@ import Footer from "main/components/Nav/Footer";
 import AppNavbar from "main/components/Nav/AppNavbar";
 import { useCurrentUser, useLogout } from "main/utils/currentUser";
 import { useSystemInfo } from "main/utils/systemInfo";
+import PropTypes from "prop-types";
 
 export default function BasicLayout({ children }) {
   const currentUser = useCurrentUser();
@@ -24,3 +25,6 @@ export default function BasicLayout({ children }) {
     </div>
   );
 }
+BasicLayout.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/frontend/src/main/pages/Admin/AdminsCreatePage.jsx
+++ b/frontend/src/main/pages/Admin/AdminsCreatePage.jsx
@@ -3,6 +3,7 @@ import RoleEmailForm from "main/components/Users/RoleEmailForm";
 import { Navigate } from "react-router";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
+import PropTypes from "prop-types";
 
 export default function AdminsCreatePage({ storybook = false }) {
   const objectToAxiosParams = (admin) => ({
@@ -43,3 +44,7 @@ export default function AdminsCreatePage({ storybook = false }) {
     </BasicLayout>
   );
 }
+
+AdminsCreatePage.propTypes = {
+  storybook: PropTypes.bool,
+};

--- a/frontend/src/main/pages/Admin/InstructorsCreatePage.jsx
+++ b/frontend/src/main/pages/Admin/InstructorsCreatePage.jsx
@@ -3,6 +3,7 @@ import RoleEmailForm from "main/components/Users/RoleEmailForm";
 import { useNavigate } from "react-router";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
+import PropTypes from "prop-types";
 
 export default function InstructorsCreatePage({ storybook = false }) {
   const navigation = useNavigate();
@@ -39,3 +40,7 @@ export default function InstructorsCreatePage({ storybook = false }) {
     </BasicLayout>
   );
 }
+
+InstructorsCreatePage.propTypes = {
+  storybook: PropTypes.bool,
+};

--- a/frontend/src/main/pages/Auth/ProtectedPage.jsx
+++ b/frontend/src/main/pages/Auth/ProtectedPage.jsx
@@ -2,6 +2,7 @@ import { hasRole } from "main/utils/currentUser";
 import AccessDeniedPage from "main/pages/Auth/AccessDeniedPage";
 import PromptSignInPage from "main/pages/Auth/PromptSignInPage";
 import LoadingPage from "main/pages/LoadingPage";
+import PropTypes from "prop-types";
 
 export default function ProtectedPage({ component, currentUser, enforceRole }) {
   if (currentUser.initialData) {
@@ -15,3 +16,15 @@ export default function ProtectedPage({ component, currentUser, enforceRole }) {
     return <AccessDeniedPage />;
   }
 }
+
+ProtectedPage.propTypes = {
+  component: PropTypes.element.isRequired,
+  currentUser: PropTypes.shape({
+    initialData: PropTypes.bool,
+    loggedIn: PropTypes.bool,
+    root: PropTypes.shape({
+      rolesList: PropTypes.arrayOf(PropTypes.string),
+    }),
+  }).isRequired,
+  enforceRole: PropTypes.string,
+};

--- a/frontend/src/stories/pages/Admin/CoursesIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/Admin/CoursesIndexPage.stories.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import coursesFixtures from "fixtures/coursesFixtures";
@@ -28,6 +29,9 @@ const QueryWrapper = ({ children }) => {
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
+};
+QueryWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
 };
 
 const Template = () => (

--- a/frontend/src/stories/pages/HomePageLoggedIn.stories.jsx
+++ b/frontend/src/stories/pages/HomePageLoggedIn.stories.jsx
@@ -2,6 +2,7 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { http, HttpResponse } from "msw";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import PropTypes from "prop-types";
 
 import HomePageLoggedIn from "main/pages/HomePageLoggedIn";
 import coursesFixtures from "fixtures/coursesFixtures";
@@ -24,6 +25,9 @@ const QueryWrapper = ({ children }) => {
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
+};
+QueryWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
 };
 
 const Template = () => (

--- a/frontend/src/tests/components/Common/OurPagination.test.jsx
+++ b/frontend/src/tests/components/Common/OurPagination.test.jsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import OurPagination from "main/components/Common/OurPagination";
 import { useState } from "react";
 import { vi } from "vitest";
+import PropTypes from "prop-types";
 
 const checkTestIdsInOrder = (testIds) => {
   const links = screen.getAllByTestId(/OurPagination-/);
@@ -27,6 +28,10 @@ const PaginationWrapper = ({ beginActivePage, args }) => {
       {...args}
     />
   );
+};
+PaginationWrapper.propTypes = {
+  beginActivePage: PropTypes.number.isRequired,
+  args: PropTypes.object,
 };
 
 describe("OurPagination tests", () => {

--- a/frontend/src/tests/components/Courses/CourseModal.test.jsx
+++ b/frontend/src/tests/components/Courses/CourseModal.test.jsx
@@ -1,5 +1,6 @@
 import CourseModal from "main/components/Courses/CourseModal";
 import React from "react";
+import PropTypes from "prop-types";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import coursesFixtures from "fixtures/coursesFixtures";
 import { vi } from "vitest";
@@ -151,7 +152,9 @@ describe("CourseModal Tests", () => {
         />
       </div>
     );
-
+    MockCourseModal.propTypes = {
+      initialContents: PropTypes.object,
+    };
     // Start with no initial contents
     const { rerender } = render(<MockCourseModal initialContents={null} />);
 
@@ -191,7 +194,9 @@ describe("CourseModal Tests", () => {
         />
       </div>
     );
-
+    MockCourseModal.propTypes = {
+      initialContents: PropTypes.object,
+    };
     // Start with first course
     const { rerender } = render(
       <MockCourseModal initialContents={coursesFixtures.severalCourses[0]} />,
@@ -233,7 +238,9 @@ describe("CourseModal Tests", () => {
         />
       </div>
     );
-
+    MockCourseModal.propTypes = {
+      initialContents: PropTypes.object,
+    };
     // Start with undefined initial contents
     const { rerender } = render(
       <MockCourseModal initialContents={undefined} />,


### PR DESCRIPTION
Closes #16

Enables the eslint rule "react/prop-types" and adds PropTypes everywhere they are required

PR branch hosted at https://frontiers-dev-kosnax.dokku-11.cs.ucsb.edu/

Note : As this PR introduces an additional Eslint Rule, if other PR's are merged before it, this may no longer pass the Eslint check due to the other PR's not following the new Eslint Rule.

Note 2: PropTypes can be as generic as PropType.object and eslint will count that as meeting its linting requirements, but doing so defeats the purpose of using PropTypes in the first place. In order to make PropTypes useful for development, I used the following reasoning when adding PropTypes:

### If an object has type properties mentioned within the context of the file, I assigned it that type:
```javascript
// E.x. If ObjectA = true =>
ObjectA: PropTypes.bool
```
### If an object does not have a default value and the file does not contain a catch to check if the object is null, I made it required:
```javascript
// E.x.
ObjectA: PropTypes.bool.isRequired
```

### If an object has child properties that are used within the file (used directly or within forms), I added shape requirements:
```javascript
// E.x. header.column.id = "objectID" =>
header: PropTypes.shape({
  column: PropTypes.shape({
    id: PropTypes.string.isRequired,
  }).isRequired,
}).isRequired,
```

### If an object uses an exported function that requires an object to have properties (I.E. currentUser.js with hasRole()), I added shape requirements for those properties:
```javascript
// E.x. hasRole(currentUser, "ROLE_ADMIN") =>
currentUser: PropTypes.shape({
  root: PropTypes.shape({
    rolesList: PropTypes.arrayOf(PropTypes.string),
  }),
}).isRequired,
// Note this is because `hasRole` mentions currentUser.root?.rolesList?.includes(role)
```
